### PR TITLE
chore(docs): add ruby-phosphor-icons in community projects

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,7 @@ If you'd like to use the assets directly, you can download our [asset kit](https
 - [phosphor-svelte](https://github.com/haruaki07/phosphor-svelte) ▲ Phosphor icons for Svelte apps
 - [phosphor-r](https://github.com/dreamRs/phosphoricons) ▲ Phosphor icon wrapper for R documents and applications
 - [blade-phosphor-icons](https://github.com/codeat3/blade-phosphor-icons) ▲ Phosphor icons in your Laravel Blade views
+- [ruby-phosphor-icons](https://github.com/maful/ruby-phosphor-icons) ▲ Phosphor icons for Ruby and Rails applications
 
 If you've made a port of Phosphor and you want to see it here, just open a PR [here](https://github.com/phosphor-icons/phosphor-home)!
 


### PR DESCRIPTION
related to https://github.com/phosphor-icons/homepage/pull/286